### PR TITLE
Fixing a positive lookbehind regexr to allow working with any python regexr version

### DIFF
--- a/kdeconnect-ext.py
+++ b/kdeconnect-ext.py
@@ -38,7 +38,7 @@ class KDEConnectExtension(GObject.GObject, Nautilus.MenuProvider):
         try:
             devices = get_available_devices()
         except Exception as e:
-            raise Exception("Failed to get available devices")
+            raise Exception("Failed to get available devices: " + e.message)
 
         files_new = []
         folder_list = []

--- a/kdeconnect.py
+++ b/kdeconnect.py
@@ -19,6 +19,6 @@ def get_available_devices():
     devices.pop()
     for device in devices:
         device_name=re.search("(?<=-\s).+(?=:\s)", device).group(0)
-        device_id=re.search("(?<=:\s)[a-z0-9]+(?=\s\()", device).group(0).strip()
+        device_id=re.search("((\w|\d)+)(?=\s\()", device).group(0).strip()
         devices_a.append({ "name": device_name, "id": device_id })
     return devices_a


### PR DESCRIPTION
I've noticed that there were a bug with the positive lookbehind to get the ":" in the device id getting regexr.
This PR removes the unnecessary regexr lookbehind and stop triggering exeption, rendenring the extension useless.