### PR TITLE
Convert to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,19 @@ In addition to [KDE Connect](https://community.kde.org/KDEConnect), this extensi
 
 *nautilus-kdeconnect* can also be used with the Nemo file manager:
 
-1. On your PC, install the `kdeconnect`, `python-nemo` and `libnotify-bin` packages.
+1. On your PC, install the `kdeconnect`, `python-nemo`, `libnotify-bin` and `git` packages.
      * If you are using some Debian-based distribution that is not *Linux Mint*, you won't find the `python-nemo` package in the software repositories:
         1. Download and install the [`python-nemo` package](http://packages.linuxmint.com/pool/backport/n/nemo-python/) from the *Linux Mint* package archive site.
         2. Run `sudo ln -s /usr/lib/nemo/extensions-3.0/libnemo-python.so /usr/lib/x86_64-linux-gnu/nemo/extensions-3.0/` to create a compatibility symlink to newly installed the extension file.
 2. Install the KDE Connect app for Android as mentioned above ([Google Play](https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp) / [F-Droid](https://f-droid.org/repository/browse/?fdid=org.kde.kdeconnect_tp)).
 3. Launch KDE Connect on your PC and on your Android device. Pair the two devices and enable the sharing plugin.
-4. Clone this repository and install the extension with the `Nemo` target: `git clone https://github.com/forabi/nautilus-kdeconnect nemo-kdeconnect && make -C nemo-kdeconnect install TARGET=Nemo`.
+4. Clone this repository and install the extension with the `Nemo` target: `git clone https://github.com/Dragoncraft89/nautilus-kdeconnect nemo-kdeconnect && make -C nemo-kdeconnect install TARGET=Nemo`.
+
+### Caja file manager
+
+*nautilus-kdeconnect* can also be used with the Caja file manager:
+
+1. On your PC, install the `kdeconnect`, `python-caja`, `libnotify-bin` and `git` packages.
+2. Install the KDE Connect app for Android as mentioned above ([Google Play](https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp) / [F-Droid](https://f-droid.org/repository/browse/?fdid=org.kde.kdeconnect_tp)).
+3. Launch KDE Connect on your PC and on your Android device. Pair the two devices and enable the sharing plugin.
+4. Clone this repository and install the extension with the `Caja` target: `git clone https://github.com/Dragoncraft89/nautilus-kdeconnect caja-kdeconnect && make -C caja-kdeconnect install TARGET=Caja`

--- a/kdeconnect-ext.py
+++ b/kdeconnect-ext.py
@@ -3,6 +3,8 @@ from subprocess import check_output, call
 from gi.repository import GObject
 from kdeconnect import send_files, get_available_devices
 import zipfile
+import urllib
+import urlparse
 
 TARGET = "%%TARGET%%".title()
 Nautilus = importlib.import_module("gi.repository.{}".format(TARGET))
@@ -17,22 +19,21 @@ class KDEConnectExtension(GObject.GObject, Nautilus.MenuProvider):
         import os
         for root, dirs, files in os.walk(path):
             for file in files:
-                ziph.write(os.path.join(root, file))
+                print(dirs + [file])
+                ziph.write(os.path.join(root, file), os.path.join(*(dirs + [file])))
 
     def menu_activate_cb(self, menu, files, device_id, device_name, folder_list):
         import zipfile
         import os
         for folder_name in folder_list:
-            zip_name = folder_name + '.zip'
-            zipf = zipfile.ZipFile(zip_name[7:], 'w', zipfile.ZIP_DEFLATED)
-            self.zipdir(folder_name + '/', zipf)
+            zip_name = urllib.url2pathname(urlparse.urlparse(folder_name + '.zip').path)
+            zipf = zipfile.ZipFile(zip_name, 'w', zipfile.ZIP_DEFLATED)
+            self.zipdir(zip_name[:-4] + '/', zipf)
             zipf.close()
-            zipfile = Nautilus.FileInfo.create_for_uri(zip_name)
+            zipfile = Nautilus.FileInfo.create_for_uri(folder_name + '.zip')
             files.append(zipfile)
 
         send_files(files, device_id, device_name)
-        for folder_name in folder_list:
-             os.remove(folder_name[7:] + '.zip')
 
     def get_file_items(self, window, files):
         try:

--- a/kdeconnect-ext.py
+++ b/kdeconnect-ext.py
@@ -10,7 +10,7 @@ Nautilus = importlib.import_module("gi.repository.{}".format(TARGET))
 
 class KDEConnectExtension(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):
-        pass
+        GObject.Object.__init__(self)
 
     def zipdir(self, path, ziph):
         # ziph is zipfile handle
@@ -31,8 +31,8 @@ class KDEConnectExtension(GObject.GObject, Nautilus.MenuProvider):
             files.append(zipfile)
 
         send_files(files, device_id, device_name)
-        # for folder_name in folder_list:
-        #     os.remove(folder_name[7:] + '.zip')
+        for folder_name in folder_list:
+             os.remove(folder_name[7:] + '.zip')
 
     def get_file_items(self, window, files):
         try:
@@ -49,8 +49,8 @@ class KDEConnectExtension(GObject.GObject, Nautilus.MenuProvider):
                 folder_list.append(files[i].get_uri())
 
         files = files_new
-        print files
-        print folder_list
+        print(files)
+        print(folder_list)
 
         if (len(files_new) + len(folder_list) < 1):
             return []

--- a/kdeconnect.py
+++ b/kdeconnect.py
@@ -5,7 +5,7 @@ def send_files(files, device_id, device_name):
     # results=[]
     # failed=0
     for file in files:
-        print "filename", file.get_uri()
+        print("filename", file.get_uri())
         return_code=call(["kdeconnect-cli", "-d", device_id, "--share", file.get_uri()])
         # if (return_code != 0):
         #     failed += 1
@@ -15,10 +15,12 @@ def send_files(files, device_id, device_name):
 
 def get_available_devices():
     devices_a=[]
-    devices = check_output(["kdeconnect-cli", "-a"]).strip().split("\n")
+    devices = check_output(["kdeconnect-cli", "-a"]).decode("utf-8").strip().split("\n")
     devices.pop()
+    print(devices)
     for device in devices:
         device_name=re.search("(?<=-\s).+(?=:\s)", device).group(0)
-        device_id=re.search("(?<=:\s)[a-z0-9]+(?=\s\()", device).group(0).strip()
+        device_id=re.search("(?<=:\s)[a-z0-9_]+(?=\s\()", device).group(0).strip()
         devices_a.append({ "name": device_name, "id": device_id })
+    print(devices_a)
     return devices_a

--- a/kdeconnect.py
+++ b/kdeconnect.py
@@ -2,16 +2,8 @@ from subprocess import check_output, call
 import re
 
 def send_files(files, device_id, device_name):
-    # results=[]
-    # failed=0
     for file in files:
-        print("filename", file.get_uri())
         return_code=call(["kdeconnect-cli", "-d", device_id, "--share", file.get_uri()])
-        # if (return_code != 0):
-        #     failed += 1
-        # results.append(return_code)
-    call(["notify-send", "Sending {num_files} file(s) to {device_name}. Check your device.".format(num_files=len(files), device_name=device_name)])
-    # return results
 
 def get_available_devices():
     devices_a=[]


### PR DESCRIPTION
This merge request converts the extension to valid python3 (as is required to get it to work nowadays) and fixed the sending of directories

@kelebek333 has improved the Readme and added instructions for the Caja file manager