### PR TITLE
Correction of installation guidelines for Nemo in Debian-based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ In addition to [KDE Connect](https://community.kde.org/KDEConnect), this extensi
 
 *nautilus-kdeconnect* can also be used with the Nemo file manager:
 
-1. On your PC, install the `kdeconnect`, `python-nemo`, `libnotify-bin` and `git` packages.
-     * If you are using some Debian-based distribution that is not *Linux Mint*, you won't find the `python-nemo` package in the software repositories:
-        1. Download and install the [`python-nemo` package](http://packages.linuxmint.com/pool/backport/n/nemo-python/) from the *Linux Mint* package archive site.
-        2. Run `sudo ln -s /usr/lib/nemo/extensions-3.0/libnemo-python.so /usr/lib/x86_64-linux-gnu/nemo/extensions-3.0/` to create a compatibility symlink to newly installed the extension file.
+1. On your PC, install the `kdeconnect`, `nemo-python`, `libnotify-bin` and `git` packages.
 2. Install the KDE Connect app for Android as mentioned above ([Google Play](https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp) / [F-Droid](https://f-droid.org/repository/browse/?fdid=org.kde.kdeconnect_tp)).
 3. Launch KDE Connect on your PC and on your Android device. Pair the two devices and enable the sharing plugin.
 4. Clone this repository and install the extension with the `Nemo` target: `git clone https://github.com/forabi/nautilus-kdeconnect nemo-kdeconnect && make -C nemo-kdeconnect install TARGET=Nemo`.


### PR DESCRIPTION
The nemo-python package is available in Debian since Stretch, also ubuntu has it in the repo since Disco. Furthermore, there is no need to create a symlink as the libnemo-python.so file is installed in /usr/lib/x86_64-linux-gnu/nemo/extensions-3.0/ by default.

Thus I updated the installation guidelines for Nemo in Debian based Distros.