### PR TITLE
fix: urlparse renamed to urllib.parse in python3 (import fix)

### DIFF
--- a/kdeconnect-ext.py
+++ b/kdeconnect-ext.py
@@ -4,7 +4,10 @@ from gi.repository import GObject
 from kdeconnect import send_files, get_available_devices
 import zipfile
 import urllib
-import urlparse
+try:
+    import urlparse
+except ModuleNotFoundError:
+    import urllib.parse
 
 TARGET = "%%TARGET%%".title()
 Nautilus = importlib.import_module("gi.repository.{}".format(TARGET))


### PR DESCRIPTION
just 3 lines fix of import error on python3 which is the default on most systems. 